### PR TITLE
Fixed Testing Path in BUILD.sh

### DIFF
--- a/toolchain/compilers/frontend/mrald-craft/BUILD.sh
+++ b/toolchain/compilers/frontend/mrald-craft/BUILD.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+os=$(uname -o)
+
 #echo 
 #echo +===============================+
 #echo + Cleaning Mrald-Craft.. ++++++++
@@ -28,7 +30,11 @@ echo + Testing Mrald-Craft CLI.. +++++
 echo +===============================+
 echo 
 
-./bin/Debug/mrald_craft_cli.exe
+if [[ "$os" == 'Msys' ]]; then
+	./bin/Debug/mrald_craft_cli.exe
+else
+	./bin/mrald_craft_cli
+fi
 
 cd ../..
 
@@ -50,7 +56,11 @@ echo + Testing Mrald-Craft Parser.. ++
 echo +===============================+
 echo 
 
-./bin/Debug/mrald_craft_parser.exe
+if [[ "$os" == 'Msys' ]]; then
+	./bin/Debug/mrald_craft_parser.exe
+else
+	./bin/mrald_craft_parser
+fi
 
 cd ../..
 
@@ -72,7 +82,11 @@ echo + Testing Mrald-Craft Scanner.. +
 echo +===============================+
 echo 
 
-./bin/Debug/mrald_craft_scanner.exe
+if [[ "$os" == 'Msys' ]]; then
+	./bin/Debug/mrald_craft_scanner.exe
+else
+	./bin/mrald_craft_scanner
+fi
 
 cd ../..
 


### PR DESCRIPTION
* The CMake executable path is different under Windows.
* The commit detects the os and select the appropriate path for the testing executable.
* This is not bullet-proof yet, as changing the build config might change the bin folder name.
* Further testing is required for standalone (Windows, MacOS, Unix) platforms.